### PR TITLE
listenerをremoveできない不具合を修正

### DIFF
--- a/lib/mixins/listenMix.js
+++ b/lib/mixins/listenMix.js
@@ -28,16 +28,17 @@ function listenMix (Class) {
       const closeFuncs = []
       const {resourceName} = this
       for (const [event, handler] of Object.entries(handlers)) {
-        this.addListener(event, async function eventListenerWrap (...args) {
+        const handlerWrap = async function eventListenerWrap (...args) {
           try {
             return await handler(...args)
           } catch (e) {
             console.error(`[the-resource][${resourceName}] Error on listener`, e)
             throw e
           }
-        })
+        }
+        this.addListener(event, handlerWrap)
         closeFuncs.push(
-          () => this.removeListener(event, handler)
+          () => this.removeListener(event, handlerWrap)
         )
       }
       return () => closeFuncs.map((close) => close())

--- a/test/listenMixTest.js
+++ b/test/listenMixTest.js
@@ -6,6 +6,8 @@
 
 const listenMix = require('../lib/mixins/listenMix')
 const { ok, equal } = require('assert')
+const EventEmitter = require('events')
+const asleep = require('asleep')
 
 describe('listen-mix', () => {
   before(() => {
@@ -14,8 +16,16 @@ describe('listen-mix', () => {
   after(() => {
   })
 
-  it('Do test', () => {
+  it('Close listeners', async () => {
+    const Foo = listenMix(class Base extends EventEmitter {})
+    const foo = new Foo()
 
+    const close = foo.listenEvents({
+      onCreate () {}
+    })
+    equal(foo.listenerCount('onCreate'), 1)
+    close()
+    equal(foo.listenerCount('onCreate'), 0)
   })
 })
 


### PR DESCRIPTION
`addListener()`に与える関数と、`removeListener()`に与える関数が違っていたので。